### PR TITLE
Calculate buffer length of utf-8 data for json correctly

### DIFF
--- a/lib/bhttp.js
+++ b/lib/bhttp.js
@@ -257,15 +257,17 @@ preparePayload = function(request, response, requestState) {
         debugRequest("got url-encodable form-data");
         if (request.options.encodeJSON) {
           debugRequest("... but encodeJSON was set, so we will send JSON instead");
-          request.options.headers["content-type"] = "application/json";
+          request.options.headers["content-type"] = "application/json; charset=utf-8";
           request.payload = JSON.stringify((ref1 = request.options.formFields) != null ? ref1 : null);
+          request.options.headers["content-length"] = Buffer.byteLength(request.payload, "utf8");
         } else if (!_.isEmpty(request.options.formFields)) {
           request.options.headers["content-type"] = "application/x-www-form-urlencoded";
           request.payload = querystring.stringify(formFixArray(request.options.formFields));
+          request.options.headers["content-length"] = request.payload.length;
         } else {
           request.payload = "";
+          request.options.headers["content-length"] = 0;
         }
-        request.options.headers["content-length"] = request.payload.length;
         return Promise.resolve();
       } else if ((request.options.formFields != null) && multipart) {
         debugRequest("got multipart form-data");

--- a/test-utf8-json.coffee
+++ b/test-utf8-json.coffee
@@ -1,0 +1,22 @@
+Promise = require "bluebird"
+bhttp = require "./"
+
+formatLine = (line) -> line.toString().replace(/\n/g, "\\n").replace(/\r/g, "\\r")
+
+# this just tests we can parse the data we sent. if ever we send
+# more data than the content-length it will probably be broken
+Promise.try ->
+    bhttp.post "http://posttestserver.com/post.php",
+        value: "hello \ud801\udc37",
+    ,
+        encodeJSON: true,
+        headers: {"user-agent": "bhttp/test POST UTF-8 JSON"}
+.then (response) ->
+    responseUrl = response.body.toString().split("\n")[1].replace(/^View it at /, "")
+    console.log responseUrl
+    bhttp.get responseUrl
+.then (response) ->
+    lines = response.body.toString().split("\n")
+    JSON.parse lines[lines.length-1]
+.then (obj) ->
+    console.log "POST UTF-8 string", obj


### PR DESCRIPTION
Since we're explicitly calculating the utf-8 length (as far as I can tell, this is an implicit assumption overall) when encoding JSON, I made sure to add it to the Content-Type header too.

The denormalization of the content-length header is so we don't have to do the extra work of calculating the utf8-length if we don't have to.

There is no real test structure to speak of, so I just tested the failing case before and after to ensure it succeeds.

Closes https://github.com/joepie91/node-bhttp/issues/28